### PR TITLE
Update to 1.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.13@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f
 
 # renovate: datasource=github-releases depName=zerotier/ZeroTierOne
-ENV ZEROTIER_VERSION=1.6.5
+ENV ZEROTIER_VERSION=1.6.6
 
-ENV ZEROTIER_COMMIT=e8f7d5ef9e7ba6be0b2163cfa31f8817ba5b18f4
+ENV ZEROTIER_COMMIT=eb1cafcd0194876ab2a5d24ac369091b2a25e9d3
 
 RUN set -eux; \
     apk add --no-cache \


### PR DESCRIPTION
Update to Zero Tier One 1.6.6 which contains major patch update, 
see: https://www.zerotier.com/2021/09/21/incident-response-to-september-20th-2021/